### PR TITLE
Implement survival loop batch C: food, fatigue, death

### DIFF
--- a/Assets/_Project/Scripts/Core/Items/ItemDatabase.cs
+++ b/Assets/_Project/Scripts/Core/Items/ItemDatabase.cs
@@ -28,7 +28,8 @@ namespace ApexShift.Core.Items
                 new ItemDefinition(new ItemId("wood"), "Wood", 20),
                 new ItemDefinition(new ItemId("stone"), "Stone", 20),
                 new ItemDefinition(new ItemId("fiber"), "Fiber", 20),
-                new ItemDefinition(new ItemId("meat"), "Meat", 20),
+                new ItemDefinition(new ItemId("meat"), "Meat", 20, isEdible: true, hungerRestore: 32f, healthRestore: 0f, staminaRestore: 6f, isUnsafeRawFood: true),
+                new ItemDefinition(new ItemId("cooked_meat"), "Cooked Meat", 20, isEdible: true, hungerRestore: 45f, healthRestore: 6f, staminaRestore: 10f),
                 new ItemDefinition(new ItemId("hide"), "Hide", 20),
                 new ItemDefinition(new ItemId("bone"), "Bone", 20),
                 new ItemDefinition(new ItemId("torch"), "Torch", 1),
@@ -41,7 +42,7 @@ namespace ApexShift.Core.Items
                 new ItemDefinition(new ItemId("trap"), "Trap", 1),
                 new ItemDefinition(new ItemId("wall"), "Wall", 20),
                 new ItemDefinition(new ItemId("storage_box"), "Storage Box", 1),
-                new ItemDefinition(new ItemId("berries"), "Berries", 20),
+                new ItemDefinition(new ItemId("berries"), "Berries", 20, isEdible: true, hungerRestore: 18f, healthRestore: 1f, staminaRestore: 4f),
                 new ItemDefinition(new ItemId("grass"), "Grass", 20),
                 new ItemDefinition(new ItemId("tent"), "Tent", 1)
             });
@@ -60,6 +61,12 @@ namespace ApexShift.Core.Items
         public bool HasItem(string itemId) => HasItem(NormalizeItemId(itemId));
 
         public bool HasItem(ItemId itemId) => itemId.IsValid && definitionsById.ContainsKey(itemId.ToString());
+
+        public bool IsEdible(string itemId)
+        {
+            ItemId itemIdValue = NormalizeItemId(itemId);
+            return HasItem(itemIdValue) && GetDefinition(itemIdValue).IsEdible;
+        }
 
         public ItemId NormalizeItemId(string value)
         {

--- a/Assets/_Project/Scripts/Core/Items/ItemDefinition.cs
+++ b/Assets/_Project/Scripts/Core/Items/ItemDefinition.cs
@@ -7,8 +7,21 @@ namespace ApexShift.Core.Items
         public ItemId Id { get; }
         public string DisplayName { get; }
         public int MaxStackSize { get; }
+        public bool IsEdible { get; }
+        public float HungerRestore { get; }
+        public float HealthRestore { get; }
+        public float StaminaRestore { get; }
+        public bool IsUnsafeRawFood { get; }
 
-        public ItemDefinition(ItemId id, string displayName, int maxStackSize)
+        public ItemDefinition(
+            ItemId id,
+            string displayName,
+            int maxStackSize,
+            bool isEdible = false,
+            float hungerRestore = 0f,
+            float healthRestore = 0f,
+            float staminaRestore = 0f,
+            bool isUnsafeRawFood = false)
         {
             if (!id.IsValid)
             {
@@ -25,10 +38,29 @@ namespace ApexShift.Core.Items
                 throw new ArgumentOutOfRangeException(nameof(maxStackSize), "Max stack size must be at least 1.");
             }
 
+            if (hungerRestore < 0f)
+            {
+                throw new ArgumentOutOfRangeException(nameof(hungerRestore), "Food values cannot be negative.");
+            }
+
+            if (healthRestore < 0f)
+            {
+                throw new ArgumentOutOfRangeException(nameof(healthRestore), "Food values cannot be negative.");
+            }
+
+            if (staminaRestore < 0f)
+            {
+                throw new ArgumentOutOfRangeException(nameof(staminaRestore), "Food values cannot be negative.");
+            }
+
             Id = id;
             DisplayName = displayName.Trim();
             MaxStackSize = maxStackSize;
+            IsEdible = isEdible;
+            HungerRestore = hungerRestore;
+            HealthRestore = healthRestore;
+            StaminaRestore = staminaRestore;
+            IsUnsafeRawFood = isUnsafeRawFood;
         }
     }
 }
-

--- a/Assets/_Project/Scripts/Runtime/Player/FoodConsumptionResult.cs
+++ b/Assets/_Project/Scripts/Runtime/Player/FoodConsumptionResult.cs
@@ -1,0 +1,39 @@
+namespace ApexShift.Runtime.Player
+{
+    public readonly struct FoodConsumptionResult
+    {
+        public FoodConsumptionResult(
+            bool success,
+            string itemId,
+            string displayName,
+            string message,
+            float hungerDelta,
+            float healthDelta,
+            float staminaDelta,
+            bool unsafeRawFood)
+        {
+            Success = success;
+            ItemId = itemId ?? string.Empty;
+            DisplayName = displayName ?? string.Empty;
+            Message = message ?? string.Empty;
+            HungerDelta = hungerDelta;
+            HealthDelta = healthDelta;
+            StaminaDelta = staminaDelta;
+            UnsafeRawFood = unsafeRawFood;
+        }
+
+        public bool Success { get; }
+        public string ItemId { get; }
+        public string DisplayName { get; }
+        public string Message { get; }
+        public float HungerDelta { get; }
+        public float HealthDelta { get; }
+        public float StaminaDelta { get; }
+        public bool UnsafeRawFood { get; }
+
+        public static FoodConsumptionResult Failed(string message)
+        {
+            return new FoodConsumptionResult(false, string.Empty, string.Empty, message, 0f, 0f, 0f, false);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Runtime/Player/InventoryPanelUI.cs
+++ b/Assets/_Project/Scripts/Runtime/Player/InventoryPanelUI.cs
@@ -16,6 +16,7 @@ namespace ApexShift.Runtime.Player
         private Canvas canvas;
         private RectTransform gridRoot;
         private Text titleText;
+        private Text feedbackText;
         private Font font;
         private readonly List<GameObject> spawned = new List<GameObject>();
         private readonly Dictionary<string, Sprite> iconCache = new Dictionary<string, Sprite>(System.StringComparer.OrdinalIgnoreCase);
@@ -99,7 +100,7 @@ namespace ApexShift.Runtime.Player
                 for (int i = 0; i < inv.SlotCount; i++)
                 {
                     InventorySlotSnapshot slot = inv.PeekSlotStack(i);
-                    CreateSlot(gridRoot, slot.ItemId, slot.Amount);
+                    CreateSlot(gridRoot, i, slot.ItemId, slot.Amount);
                 }
             }
         }
@@ -126,18 +127,20 @@ namespace ApexShift.Runtime.Player
             rt.anchorMin = new Vector2(0.5f, 0.5f);
             rt.anchorMax = new Vector2(0.5f, 0.5f);
             rt.pivot = new Vector2(0.5f, 0.5f);
-            rt.sizeDelta = new Vector2(360f, 380f);
+            rt.sizeDelta = new Vector2(380f, 430f);
             panel.GetComponent<Image>().color = new Color(0.06f, 0.08f, 0.06f, 0.92f);
 
             titleText = CreateText(rt, "Title", "Inventory", 24, TextAnchor.MiddleLeft, new Vector2(18f, -18f), new Vector2(300f, 30f), true);
             CreateButton(rt, "CloseButton", "Close", new Vector2(92f, 30f), new Vector2(-52f, -18f), Close);
+            feedbackText = CreateText(rt, "Feedback", "Left click edible item to eat. Right click to drop.", 13, TextAnchor.MiddleLeft, new Vector2(18f, -386f), new Vector2(340f, 34f), false);
+            feedbackText.color = new Color(0.85f, 0.95f, 0.75f, 1f);
 
             GameObject gridGo = new GameObject("Grid", typeof(RectTransform), typeof(GridLayoutGroup));
             gridGo.transform.SetParent(rt, false);
             gridRoot = gridGo.GetComponent<RectTransform>();
             gridRoot.anchorMin = new Vector2(0f, 0f);
             gridRoot.anchorMax = new Vector2(1f, 1f);
-            gridRoot.offsetMin = new Vector2(18f, 18f);
+            gridRoot.offsetMin = new Vector2(18f, 58f);
             gridRoot.offsetMax = new Vector2(-18f, -60f);
 
             GridLayoutGroup grid = gridGo.GetComponent<GridLayoutGroup>();
@@ -147,7 +150,7 @@ namespace ApexShift.Runtime.Player
             grid.spacing = new Vector2(8f, 8f);
         }
 
-        private void CreateSlot(Transform parent, string itemId, int amount)
+        private void CreateSlot(Transform parent, int slotIndex, string itemId, int amount)
         {
             bool hasItem = amount > 0 && !string.IsNullOrWhiteSpace(itemId);
             GameObject slot = new GameObject("Slot", typeof(RectTransform), typeof(Image), typeof(CanvasGroup), typeof(SlotClickHandler), typeof(SlotDragHandler));
@@ -182,7 +185,7 @@ namespace ApexShift.Runtime.Player
             amountRt.offsetMin = new Vector2(4f, 4f);
             amountRt.offsetMax = new Vector2(-4f, -4f);
 
-            slot.GetComponent<SlotClickHandler>().Bind(this, itemId, amount, icon, amountText);
+            slot.GetComponent<SlotClickHandler>().Bind(this, slotIndex, itemId, amount, icon, amountText);
             slot.GetComponent<SlotDragHandler>().Bind(this, itemId, amount, icon);
         }
 
@@ -205,6 +208,7 @@ namespace ApexShift.Runtime.Player
                 "stone" => "ApexShift2D/Art/Icons/Resources/resource_stone",
                 "fiber" => "ApexShift2D/Art/Icons/Resources/resource_fiber",
                 "meat" => "ApexShift2D/Art/Icons/Resources/resource_raw_meat",
+                "cooked_meat" => "ApexShift2D/Art/Icons/Resources/resource_raw_meat",
                 "hide" => "ApexShift2D/Art/Icons/Resources/resource_hide",
                 "bone" => "ApexShift2D/Art/Icons/Resources/resource_bone",
                 "berries" => "ApexShift2D/Art/Icons/Resources/resource_berries",
@@ -286,6 +290,18 @@ namespace ApexShift.Runtime.Player
             eventSystem.AddComponent<InputSystemUIInputModule>();
         }
 
+        public void EatSlot(int slotIndex)
+        {
+            if (inventoryRuntime == null || inventoryRuntime.Inventory == null)
+            {
+                return;
+            }
+
+            FoodConsumptionResult result = inventoryRuntime.TryEatSlot(slotIndex);
+            SetFeedback(result.Message, result.Success);
+            Refresh();
+        }
+
         public void DropItem(string itemId, int amount)
         {
             if (inventoryRuntime == null || inventoryRuntime.Inventory == null || string.IsNullOrWhiteSpace(itemId) || amount <= 0)
@@ -308,20 +324,34 @@ namespace ApexShift.Runtime.Player
                 + right * spread.x
                 + Vector3.up * (0.2f + Mathf.Abs(spread.y));
             ItemPickupSpawner.Spawn(itemId, removed, spawnPos, Quaternion.identity);
+            SetFeedback($"Dropped {removed}x {itemId}.", true);
             Refresh();
+        }
+
+        private void SetFeedback(string message, bool success)
+        {
+            if (feedbackText == null)
+            {
+                return;
+            }
+
+            feedbackText.text = string.IsNullOrWhiteSpace(message) ? string.Empty : message;
+            feedbackText.color = success ? new Color(0.85f, 0.95f, 0.75f, 1f) : new Color(1f, 0.62f, 0.50f, 1f);
         }
 
         private sealed class SlotClickHandler : MonoBehaviour, IPointerClickHandler
         {
             private InventoryPanelUI owner;
+            private int slotIndex;
             private string itemId;
             private int amount;
             private Image icon;
             private Text amountText;
 
-            public void Bind(InventoryPanelUI owner, string itemId, int amount, Image icon, Text amountText)
+            public void Bind(InventoryPanelUI owner, int slotIndex, string itemId, int amount, Image icon, Text amountText)
             {
                 this.owner = owner;
+                this.slotIndex = slotIndex;
                 this.itemId = itemId ?? string.Empty;
                 this.amount = amount;
                 this.icon = icon;
@@ -335,7 +365,11 @@ namespace ApexShift.Runtime.Player
                     return;
                 }
 
-                if (eventData.button == PointerEventData.InputButton.Right)
+                if (eventData.button == PointerEventData.InputButton.Left)
+                {
+                    owner.EatSlot(slotIndex);
+                }
+                else if (eventData.button == PointerEventData.InputButton.Right)
                 {
                     owner.DropItem(itemId, amount);
                 }

--- a/Assets/_Project/Scripts/Runtime/Player/PlayerDeathRuntime.cs
+++ b/Assets/_Project/Scripts/Runtime/Player/PlayerDeathRuntime.cs
@@ -1,0 +1,228 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+namespace ApexShift.Runtime.Player
+{
+    public sealed class PlayerDeathRuntime : MonoBehaviour
+    {
+        [SerializeField]
+        private PlayerSurvivalRuntime survivalRuntime;
+
+        [SerializeField]
+        private bool showRuntimeOverlay = true;
+
+        [SerializeField]
+        private bool freezeTimeOnDeath;
+
+        private readonly List<Behaviour> disabledBehaviours = new List<Behaviour>();
+        private Canvas overlayCanvas;
+        private Text messageText;
+        private bool handledDeath;
+        private float previousTimeScale = 1f;
+
+        private void Awake()
+        {
+            if (survivalRuntime == null)
+            {
+                survivalRuntime = GetComponent<PlayerSurvivalRuntime>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (survivalRuntime != null)
+            {
+                survivalRuntime.PlayerDied += OnPlayerDied;
+            }
+        }
+
+        private void Start()
+        {
+            if (survivalRuntime != null && survivalRuntime.IsDead)
+            {
+                HandleDeath(survivalRuntime.DeathReason);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (survivalRuntime != null)
+            {
+                survivalRuntime.PlayerDied -= OnPlayerDied;
+            }
+        }
+
+        private void OnPlayerDied(PlayerSurvivalRuntime source, string reason)
+        {
+            HandleDeath(reason);
+        }
+
+        private void HandleDeath(string reason)
+        {
+            if (handledDeath)
+            {
+                return;
+            }
+
+            handledDeath = true;
+            DisableGameplayBehaviours();
+            if (freezeTimeOnDeath)
+            {
+                previousTimeScale = Time.timeScale;
+                Time.timeScale = 0f;
+            }
+
+            if (showRuntimeOverlay)
+            {
+                BuildOverlayIfNeeded();
+                if (overlayCanvas != null)
+                {
+                    overlayCanvas.enabled = true;
+                }
+
+                if (messageText != null)
+                {
+                    messageText.text = string.IsNullOrWhiteSpace(reason)
+                        ? "You died"
+                        : "You died\n" + reason;
+                }
+            }
+        }
+
+        private void DisableGameplayBehaviours()
+        {
+            disabledBehaviours.Clear();
+            MonoBehaviour[] behaviours = GetComponents<MonoBehaviour>();
+            foreach (MonoBehaviour behaviour in behaviours)
+            {
+                if (behaviour == null || behaviour == this || behaviour == survivalRuntime || !behaviour.enabled)
+                {
+                    continue;
+                }
+
+                string typeName = behaviour.GetType().Name;
+                if (!ShouldDisableOnDeath(typeName))
+                {
+                    continue;
+                }
+
+                behaviour.enabled = false;
+                disabledBehaviours.Add(behaviour);
+            }
+        }
+
+        private static bool ShouldDisableOnDeath(string typeName)
+        {
+            return typeName == "PlayerInputReader"
+                   || typeName == "IsometricPlayerController"
+                   || typeName == "PlayerCombatRuntime"
+                   || typeName == "PlayerCraftingRuntime"
+                   || typeName == "PlayerHeldItemRuntime"
+                   || typeName == "BuildingPlacementRuntime"
+                   || typeName == "ActionBarRuntime";
+        }
+
+        private void BuildOverlayIfNeeded()
+        {
+            if (overlayCanvas != null)
+            {
+                return;
+            }
+
+            GameObject overlay = new GameObject("GameOverOverlay", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            overlay.transform.SetParent(transform, false);
+            overlayCanvas = overlay.GetComponent<Canvas>();
+            overlayCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            overlayCanvas.overrideSorting = true;
+            overlayCanvas.sortingOrder = 9000;
+
+            CanvasScaler scaler = overlay.GetComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1920f, 1080f);
+
+            GameObject panel = new GameObject("Panel", typeof(RectTransform), typeof(Image));
+            panel.transform.SetParent(overlay.transform, false);
+            RectTransform panelRect = panel.GetComponent<RectTransform>();
+            panelRect.anchorMin = Vector2.zero;
+            panelRect.anchorMax = Vector2.one;
+            panelRect.offsetMin = Vector2.zero;
+            panelRect.offsetMax = Vector2.zero;
+            panel.GetComponent<Image>().color = new Color(0f, 0f, 0f, 0.72f);
+
+            messageText = CreateText(panel.transform, "DeathMessage", "You died", 42, TextAnchor.MiddleCenter, new Vector2(0f, 120f), new Vector2(900f, 160f), true);
+            CreateButton(panel.transform, "RestartRunButton", "Restart Run", new Vector2(260f, 56f), new Vector2(0f, 10f), RestartRun);
+            CreateButton(panel.transform, "LoadSaveButton", "Load Last Save", new Vector2(260f, 56f), new Vector2(0f, -64f), LoadLastSavePlaceholder);
+            CreateButton(panel.transform, "MainMenuButton", "Back To Main Menu", new Vector2(260f, 56f), new Vector2(0f, -138f), BackToMainMenu);
+        }
+
+        private Text CreateText(Transform parent, string name, string text, int fontSize, TextAnchor alignment, Vector2 anchoredPosition, Vector2 size, bool bold)
+        {
+            GameObject go = new GameObject(name, typeof(RectTransform), typeof(Text));
+            go.transform.SetParent(parent, false);
+            Text label = go.GetComponent<Text>();
+            label.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            label.fontSize = fontSize;
+            label.fontStyle = bold ? FontStyle.Bold : FontStyle.Normal;
+            label.alignment = alignment;
+            label.color = Color.white;
+            label.text = text;
+            RectTransform rt = go.GetComponent<RectTransform>();
+            rt.anchorMin = new Vector2(0.5f, 0.5f);
+            rt.anchorMax = new Vector2(0.5f, 0.5f);
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.anchoredPosition = anchoredPosition;
+            rt.sizeDelta = size;
+            return label;
+        }
+
+        private Button CreateButton(Transform parent, string name, string text, Vector2 size, Vector2 anchoredPosition, UnityEngine.Events.UnityAction onClick)
+        {
+            GameObject go = new GameObject(name, typeof(RectTransform), typeof(Image), typeof(Button));
+            go.transform.SetParent(parent, false);
+            RectTransform rt = go.GetComponent<RectTransform>();
+            rt.anchorMin = new Vector2(0.5f, 0.5f);
+            rt.anchorMax = new Vector2(0.5f, 0.5f);
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.anchoredPosition = anchoredPosition;
+            rt.sizeDelta = size;
+            Image image = go.GetComponent<Image>();
+            image.color = new Color(0.24f, 0.32f, 0.24f, 1f);
+            Button button = go.GetComponent<Button>();
+            button.targetGraphic = image;
+            button.onClick.AddListener(onClick);
+            CreateText(go.transform, "Label", text, 18, TextAnchor.MiddleCenter, Vector2.zero, size, false);
+            return button;
+        }
+
+        private void RestartRun()
+        {
+            RestoreTimeScale();
+            Scene activeScene = SceneManager.GetActiveScene();
+            if (activeScene.IsValid())
+            {
+                SceneManager.LoadScene(activeScene.buildIndex);
+            }
+        }
+
+        private void LoadLastSavePlaceholder()
+        {
+            Debug.Log("[PlayerDeath] Load Last Save requested. Hook this button to GameSaveService load flow when save selection is available.", this);
+        }
+
+        private void BackToMainMenu()
+        {
+            RestoreTimeScale();
+            SceneManager.LoadScene(0);
+        }
+
+        private void RestoreTimeScale()
+        {
+            if (freezeTimeOnDeath)
+            {
+                Time.timeScale = previousTimeScale <= 0f ? 1f : previousTimeScale;
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Runtime/Player/PlayerInventoryRuntime.cs
+++ b/Assets/_Project/Scripts/Runtime/Player/PlayerInventoryRuntime.cs
@@ -1,4 +1,5 @@
 using ApexShift.Core.Inventory;
+using ApexShift.Core.Items;
 using ApexShift.Core.Save;
 using UnityEngine;
 
@@ -9,19 +10,112 @@ namespace ApexShift.Runtime.Player
         [SerializeField]
         private int slotCount = InventoryState.DefaultSlotCount;
 
+        [SerializeField]
+        private PlayerSurvivalRuntime survivalRuntime;
+
+        private ItemDatabase itemDatabase;
         private InventoryState inventory;
 
         public InventoryState Inventory => inventory;
+        public ItemDatabase ItemDatabase => itemDatabase;
 
         private void Awake()
         {
+            if (survivalRuntime == null)
+            {
+                survivalRuntime = GetComponent<PlayerSurvivalRuntime>();
+            }
+
             EnsureInitialized();
         }
 
         public void EnsureInitialized()
         {
             if (inventory != null) return;
-            inventory = new InventoryState(Core.Items.ItemDatabase.CreateDefault(), slotCount);
+            itemDatabase = ItemDatabase.CreateDefault();
+            inventory = new InventoryState(itemDatabase, slotCount);
+        }
+
+        public bool CanEat(string itemId)
+        {
+            EnsureInitialized();
+            return !string.IsNullOrWhiteSpace(itemId)
+                   && itemDatabase.HasItem(itemId)
+                   && itemDatabase.IsEdible(itemId)
+                   && inventory.GetAmount(itemId) > 0
+                   && (survivalRuntime == null || !survivalRuntime.IsDead);
+        }
+
+        public FoodConsumptionResult TryEatItem(string itemId, int amount = 1)
+        {
+            EnsureInitialized();
+            if (string.IsNullOrWhiteSpace(itemId))
+            {
+                return FoodConsumptionResult.Failed("Cannot eat empty item.");
+            }
+
+            if (survivalRuntime != null && survivalRuntime.IsDead)
+            {
+                return FoodConsumptionResult.Failed("Cannot eat after death.");
+            }
+
+            string normalizedId = itemDatabase.NormalizeItemId(itemId).ToString();
+            if (!itemDatabase.HasItem(normalizedId))
+            {
+                return FoodConsumptionResult.Failed($"Unknown item '{itemId}'.");
+            }
+
+            ItemDefinition definition = itemDatabase.GetDefinition(normalizedId);
+            if (!definition.IsEdible)
+            {
+                return FoodConsumptionResult.Failed($"Cannot eat {definition.DisplayName}.");
+            }
+
+            if (inventory.GetAmount(normalizedId) <= 0)
+            {
+                return FoodConsumptionResult.Failed($"No {definition.DisplayName} in inventory.");
+            }
+
+            int consumeAmount = Mathf.Max(1, amount);
+            if (!inventory.RemoveItem(normalizedId, consumeAmount))
+            {
+                return FoodConsumptionResult.Failed($"Could not consume {definition.DisplayName}.");
+            }
+
+            float hungerDelta = 0f;
+            float healthDelta = 0f;
+            float staminaDelta = 0f;
+            if (survivalRuntime != null)
+            {
+                hungerDelta = survivalRuntime.ApplyFood(definition.HungerRestore * consumeAmount).HungerDelta;
+                if (definition.HealthRestore > 0f)
+                {
+                    healthDelta = survivalRuntime.Heal(definition.HealthRestore * consumeAmount).HealthDelta;
+                }
+
+                if (definition.StaminaRestore > 0f)
+                {
+                    staminaDelta = survivalRuntime.RestoreStamina(definition.StaminaRestore * consumeAmount);
+                }
+            }
+
+            string message = definition.IsUnsafeRawFood
+                ? $"Ate raw {definition.DisplayName}. It helped, but may be unsafe later."
+                : $"Ate {definition.DisplayName}.";
+            Debug.Log($"[Inventory] {message} hungerDelta={hungerDelta:0.0} healthDelta={healthDelta:0.0} staminaDelta={staminaDelta:0.0}", this);
+            return new FoodConsumptionResult(true, normalizedId, definition.DisplayName, message, hungerDelta, healthDelta, staminaDelta, definition.IsUnsafeRawFood);
+        }
+
+        public FoodConsumptionResult TryEatSlot(int slotIndex)
+        {
+            EnsureInitialized();
+            InventorySlotSnapshot slot = inventory.PeekSlotStack(slotIndex);
+            if (string.IsNullOrWhiteSpace(slot.ItemId) || slot.Amount <= 0)
+            {
+                return FoodConsumptionResult.Failed("Slot is empty.");
+            }
+
+            return TryEatItem(slot.ItemId, 1);
         }
 
         public InventorySaveData ToSaveData()

--- a/Assets/_Project/Scripts/Runtime/Player/PlayerInventoryRuntime.cs
+++ b/Assets/_Project/Scripts/Runtime/Player/PlayerInventoryRuntime.cs
@@ -32,7 +32,7 @@ namespace ApexShift.Runtime.Player
         public void EnsureInitialized()
         {
             if (inventory != null) return;
-            itemDatabase = ItemDatabase.CreateDefault();
+            itemDatabase = ApexShift.Core.Items.ItemDatabase.CreateDefault();
             inventory = new InventoryState(itemDatabase, slotCount);
         }
 

--- a/Assets/_Project/Scripts/Runtime/Player/PlayerSurvivalRuntime.cs
+++ b/Assets/_Project/Scripts/Runtime/Player/PlayerSurvivalRuntime.cs
@@ -1,3 +1,4 @@
+using System;
 using ApexShift.Core.Survival;
 using ApexShift.Core.Save;
 using ApexShift.Runtime.Events;
@@ -33,6 +34,16 @@ namespace ApexShift.Runtime.Player
         [SerializeField] private float exhaustedSpeedMultiplier = 0.48f;
         [SerializeField] private float noStaminaSpeedMultiplier = 0.35f;
 
+        [Header("Fatigue / Exhaustion")]
+        [SerializeField] private float fatigueRestThreshold = 20f;
+        [SerializeField] private float exhaustionRestThreshold = 5f;
+        [SerializeField] private float lowHungerFatigueThreshold = 15f;
+        [SerializeField] private float exhaustedHealthDamagePerSecond = 0.35f;
+        [SerializeField] private float exhaustedStaminaDrainPerSecond = 2f;
+
+        [Header("Death")]
+        [SerializeField] private bool autoInstallDeathRuntime = true;
+
         [SerializeField]
         private float debugLogInterval = 2f;
 
@@ -40,14 +51,43 @@ namespace ApexShift.Runtime.Player
         private SurvivalSystem survivalSystem;
         private SurvivalStats stats;
         private float debugLogTimer;
+        private bool deathEventRaised;
+
+        public event Action<PlayerSurvivalRuntime, string> PlayerDied;
+
         public PlayerInputReader InputReader => inputReader;
         public SurvivalStats Stats => stats;
         public SurvivalSystem SurvivalSystem => survivalSystem;
         public bool WantsSprint { get; private set; }
         public bool IsSprinting { get; private set; }
-        public bool CanSprint => stats != null && survivalSystem != null && survivalSystem.CanSprint(stats);
+        public bool IsDead => stats != null && stats.Health <= 0f;
+        public bool IsFatigued => stats != null && (stats.Rest <= Mathf.Max(0f, fatigueRestThreshold) || stats.Hunger <= Mathf.Max(0f, lowHungerFatigueThreshold));
+        public bool IsExhausted => stats != null && (stats.Rest <= Mathf.Max(0f, exhaustionRestThreshold) || stats.Stamina <= 0.01f);
+        public string DeathReason { get; private set; } = string.Empty;
+        public bool CanSprint => !IsDead && stats != null && survivalSystem != null && survivalSystem.CanSprint(stats);
         public float SpeedMultiplier => stats != null && survivalSystem != null ? survivalSystem.GetSpeedMultiplier(stats) * GetStaminaSpeedMultiplier() : 1f;
-        public string ConditionText => stats != null && survivalSystem != null ? survivalSystem.GetConditionText(stats) : "uninitialized";
+        public string ConditionText
+        {
+            get
+            {
+                if (IsDead)
+                {
+                    return string.IsNullOrWhiteSpace(DeathReason) ? "dead" : "dead: " + DeathReason;
+                }
+
+                if (IsExhausted)
+                {
+                    return "exhausted";
+                }
+
+                if (IsFatigued)
+                {
+                    return "fatigued";
+                }
+
+                return stats != null && survivalSystem != null ? survivalSystem.GetConditionText(stats) : "uninitialized";
+            }
+        }
 
         private void Awake()
         {
@@ -57,15 +97,37 @@ namespace ApexShift.Runtime.Player
             }
 
             InitializeCore();
+            if (autoInstallDeathRuntime && GetComponent<PlayerDeathRuntime>() == null)
+            {
+                gameObject.AddComponent<PlayerDeathRuntime>();
+            }
         }
 
         private void Update()
         {
             EnsureInitialized();
 
+            if (IsDead)
+            {
+                WantsSprint = false;
+                IsSprinting = false;
+                RaiseDeathOnce(string.IsNullOrWhiteSpace(DeathReason) ? "unknown" : DeathReason);
+                return;
+            }
+
             WantsSprint = inputReader != null && inputReader.SprintHeld && inputReader.Move.sqrMagnitude > 0.0001f;
             SurvivalTickResult tickResult = survivalSystem.Tick(stats, Time.deltaTime, WantsSprint);
             IsSprinting = tickResult.IsSprinting;
+            ApplyFatiguePenalties(Time.deltaTime);
+
+            if (tickResult.Died)
+            {
+                RaiseDeathOnce(tickResult.DeathReason);
+            }
+            else if (stats.Health <= 0f)
+            {
+                RaiseDeathOnce(IsExhausted ? "exhaustion" : "damage");
+            }
 
             if (logToConsole)
             {
@@ -86,39 +148,80 @@ namespace ApexShift.Runtime.Player
         public SurvivalTickResult ApplyFood(float nutrition)
         {
             EnsureInitialized();
+            if (IsDead)
+            {
+                return SurvivalTickResult.NoChange(stats);
+            }
+
             return survivalSystem.ApplyFood(stats, nutrition);
         }
 
         public SurvivalTickResult EatMeat()
         {
             EnsureInitialized();
+            if (IsDead)
+            {
+                return SurvivalTickResult.NoChange(stats);
+            }
+
             return survivalSystem.ApplyFood(stats, rules.MeatNutrition);
         }
 
         public SurvivalTickResult Damage(float amount)
         {
             EnsureInitialized();
-            Debug.Log($"[PlayerSurvival] Damage called with amount: {amount}, current health: {stats.Health}");
+            if (IsDead)
+            {
+                return SurvivalTickResult.NoChange(stats);
+            }
+
             SurvivalTickResult result = survivalSystem.ApplyDamage(stats, amount);
-            Debug.Log($"[PlayerSurvival] After damage - new health: {stats.Health}, result: {result}");
+            if (result.Died || stats.Health <= 0f)
+            {
+                RaiseDeathOnce(result.Died ? result.DeathReason : "damage");
+            }
+
             return result;
         }
 
         public SurvivalTickResult Heal(float amount)
         {
             EnsureInitialized();
+            if (IsDead)
+            {
+                return SurvivalTickResult.NoChange(stats);
+            }
+
             return survivalSystem.ApplyHeal(stats, amount);
+        }
+
+        public float RestoreStamina(float amount)
+        {
+            EnsureInitialized();
+            if (amount <= 0f || IsDead)
+            {
+                return 0f;
+            }
+
+            return stats.ChangeStamina(amount);
         }
 
         public void Restore(float health, float hunger, float stamina, float rest)
         {
             EnsureInitialized();
             stats.Restore(health, hunger, stamina, rest);
+            DeathReason = string.Empty;
+            deathEventRaised = stats.Health <= 0f;
         }
 
         public void SetCampfireRegen(bool active, float nearestDistance = -1f)
         {
             EnsureInitialized();
+            if (IsDead)
+            {
+                return;
+            }
+
             stats.SetCampfireRegen(active, nearestDistance);
             if (active)
             {
@@ -149,6 +252,35 @@ namespace ApexShift.Runtime.Player
         {
             EnsureInitialized();
             stats.LoadFromSaveData(data);
+            DeathReason = stats.Health <= 0f ? "loaded_dead_state" : string.Empty;
+            deathEventRaised = stats.Health <= 0f;
+        }
+
+        private void ApplyFatiguePenalties(float deltaTime)
+        {
+            if (deltaTime <= 0f || stats == null || stats.GodMode || IsDead)
+            {
+                return;
+            }
+
+            if (!IsExhausted)
+            {
+                return;
+            }
+
+            if (exhaustedStaminaDrainPerSecond > 0f)
+            {
+                stats.ChangeStamina(-exhaustedStaminaDrainPerSecond * deltaTime);
+            }
+
+            if (stats.Rest <= Mathf.Max(0f, exhaustionRestThreshold) && exhaustedHealthDamagePerSecond > 0f)
+            {
+                SurvivalTickResult result = survivalSystem.ApplyDamage(stats, exhaustedHealthDamagePerSecond * deltaTime);
+                if (result.Died || stats.Health <= 0f)
+                {
+                    RaiseDeathOnce("exhaustion");
+                }
+            }
         }
 
         private float GetStaminaSpeedMultiplier()
@@ -176,11 +308,28 @@ namespace ApexShift.Runtime.Player
             return 1f;
         }
 
+        private void RaiseDeathOnce(string reason)
+        {
+            if (deathEventRaised)
+            {
+                return;
+            }
+
+            deathEventRaised = true;
+            DeathReason = string.IsNullOrWhiteSpace(reason) ? "unknown" : reason.Trim();
+            WantsSprint = false;
+            IsSprinting = false;
+            PlayerDied?.Invoke(this, DeathReason);
+            Debug.Log($"[PlayerSurvival] Player died: {DeathReason}", this);
+        }
+
         private void InitializeCore()
         {
             rules = SurvivalRules.CreateDefault();
             survivalSystem = new SurvivalSystem(rules);
             stats = new SurvivalStats(startingHealth, startingHunger, startingStamina, startingRest, rules);
+            DeathReason = stats.Health <= 0f ? "initial_dead_state" : string.Empty;
+            deathEventRaised = stats.Health <= 0f;
         }
 
         private void EnsureInitialized()

--- a/Assets/_Project/Scripts/Tests/Unit/Items/ItemDatabaseFoodTests.cs
+++ b/Assets/_Project/Scripts/Tests/Unit/Items/ItemDatabaseFoodTests.cs
@@ -1,0 +1,31 @@
+using ApexShift.Core.Items;
+using NUnit.Framework;
+
+namespace ApexShift.Tests.Unit.Items
+{
+    public sealed class ItemDatabaseFoodTests
+    {
+        [Test]
+        public void DefaultDatabaseMarksBerriesAndMeatAsEdible()
+        {
+            ItemDatabase database = ItemDatabase.CreateDefault();
+
+            Assert.IsTrue(database.IsEdible("berries"));
+            Assert.IsTrue(database.IsEdible("meat"));
+            Assert.IsFalse(database.IsEdible("wood"));
+        }
+
+        [Test]
+        public void EdibleDefinitionsExposeNutritionValues()
+        {
+            ItemDatabase database = ItemDatabase.CreateDefault();
+
+            ItemDefinition berries = database.GetDefinition("berries");
+            ItemDefinition meat = database.GetDefinition("meat");
+
+            Assert.Greater(berries.HungerRestore, 0f);
+            Assert.Greater(meat.HungerRestore, berries.HungerRestore);
+            Assert.IsTrue(meat.IsUnsafeRawFood);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the Batch C survival loop work:

- #62 food consumption and hunger recovery
- #63 fatigue/exhaustion/stamina penalties
- #61 player death and game-over flow

## Changes

### Food / inventory

- Adds edible item metadata to `ItemDefinition`.
- Marks `berries`, `meat`, and future-ready `cooked_meat` as edible in `ItemDatabase`.
- Adds `PlayerInventoryRuntime.TryEatItem` / `TryEatSlot`.
- Left-clicking an edible inventory slot consumes 1 item.
- Right-click still drops the stack.
- Inventory UI shows feedback such as `Ate Berries` / `Cannot eat Wood`.
- Eating is blocked when the player is dead.

### Fatigue / exhaustion

- Extends `PlayerSurvivalRuntime` with fatigue/exhaustion state.
- Low rest/stamina affects condition text and speed multiplier.
- Exhaustion can drain stamina and apply health damage over time.

### Death / game over

- Adds `PlayerDeathRuntime`.
- `PlayerSurvivalRuntime` exposes `IsDead`, `DeathReason`, and `PlayerDied` event.
- Death is raised once and does not spam events every frame.
- On death, gameplay behaviours on the player are disabled.
- Runtime `You died` overlay is created with Restart, Load Last Save placeholder, and Back To Main Menu.

### Tests

- Adds `ItemDatabaseFoodTests` for edible metadata.

## Manual test

1. Add berries to inventory, open inventory, left-click berries.
2. Confirm hunger rises and the berries stack decreases by 1.
3. Left-click wood and confirm it refuses with feedback.
4. Damage or starve the player to 0 HP.
5. Confirm movement/combat/actions stop and the game-over overlay appears.
6. Restart run from the overlay.

Closes #62
Closes #63
Closes #61
