### PR TITLE
Implement gameplay polish batch D: landmarks and player animations

### DIFF
--- a/Assets/_Project/Scripts/Editor/Animation/PlayerAnimationBindingReportWindow.cs
+++ b/Assets/_Project/Scripts/Editor/Animation/PlayerAnimationBindingReportWindow.cs
@@ -1,0 +1,86 @@
+#if UNITY_EDITOR
+using System.Text;
+using ApexShift.Runtime.Player;
+using UnityEditor;
+using UnityEngine;
+
+namespace ApexShift.Editor.Animation
+{
+    public sealed class PlayerAnimationBindingReportWindow : EditorWindow
+    {
+        private Vector2 scroll;
+        private string report = "Click Refresh to scan imported player animation clips.";
+
+        [MenuItem("Apex Shift/Animation/Player Binding Report")]
+        public static void Open()
+        {
+            GetWindow<PlayerAnimationBindingReportWindow>("Player Animations");
+        }
+
+        private void OnGUI()
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                if (GUILayout.Button("Refresh", GUILayout.Width(120f)))
+                {
+                    report = BuildReport();
+                }
+
+                if (GUILayout.Button("Generate/Refresh Controller", GUILayout.Width(210f)))
+                {
+                    RuntimeAnimatorController controller = KevinIglesiasPlayerAnimationBinder.TryBuildKevinController();
+                    report = controller != null
+                        ? BuildReport() + "\n\nGenerated controller: " + AssetDatabase.GetAssetPath(controller)
+                        : BuildReport() + "\n\nController generation failed. Missing Idle/Walk/Run clips.";
+                }
+            }
+
+            scroll = EditorGUILayout.BeginScrollView(scroll);
+            EditorGUILayout.TextArea(report, GUILayout.ExpandHeight(true));
+            EditorGUILayout.EndScrollView();
+        }
+
+        private static string BuildReport()
+        {
+            KevinIglesiasPlayerAnimationBinder.ClipResolution resolution = KevinIglesiasPlayerAnimationBinder.ResolveKevinClips();
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("Apex Shift Player Animation Binding Report");
+            sb.AppendLine("========================================");
+            sb.AppendLine();
+            sb.AppendLine("Resolved clips:");
+            AppendClip(sb, "Idle", resolution.Clips.Idle);
+            AppendClip(sb, "Walk", resolution.Clips.Walk);
+            AppendClip(sb, "Run/Sprint", resolution.Clips.Run);
+            AppendClip(sb, "Swim", resolution.Clips.Swim);
+            AppendClip(sb, "Attack", resolution.Clips.Attack);
+            AppendClip(sb, "SpearAttack", resolution.Clips.SpearAttack);
+            AppendClip(sb, "BowAttack", resolution.Clips.BowAttack);
+            AppendClip(sb, "AxeUse/Chop", resolution.Clips.AxeUse);
+            AppendClip(sb, "PickaxeUse/Mine", resolution.Clips.PickaxeUse);
+            AppendClip(sb, "TorchUse", resolution.Clips.TorchUse);
+            AppendClip(sb, "Gather/Interact", resolution.Clips.Gather);
+            AppendClip(sb, "Hurt", resolution.Clips.Hurt);
+            AppendClip(sb, "Death", resolution.Clips.Death);
+            sb.AppendLine();
+            sb.AppendLine("Candidate clips found: " + resolution.Candidates.Count);
+            sb.AppendLine();
+            sb.AppendLine("Acceptance hints:");
+            sb.AppendLine("- Idle, Walk and Run are required for generated controller creation.");
+            sb.AppendLine("- Missing action clips safely fall back to Attack/Gather triggers.");
+            sb.AppendLine("- Missing AnimatorController should not break player movement.");
+            return sb.ToString();
+        }
+
+        private static void AppendClip(StringBuilder sb, string role, AnimationClip clip)
+        {
+            if (clip == null)
+            {
+                sb.AppendLine("- " + role + ": missing");
+                return;
+            }
+
+            sb.AppendLine("- " + role + ": " + clip.name + " (" + AssetDatabase.GetAssetPath(clip) + ")");
+        }
+    }
+}
+#endif

--- a/Assets/_Project/Scripts/Runtime/Player/PlayerAnimationDriver.cs
+++ b/Assets/_Project/Scripts/Runtime/Player/PlayerAnimationDriver.cs
@@ -66,10 +66,16 @@ namespace ApexShift.Runtime.Player
         private string mineTrigger = "Mine";
 
         [SerializeField]
+        private string hurtTrigger = "Hurt";
+
+        [SerializeField]
+        private string deathTrigger = "Death";
+
+        [SerializeField]
         private float crossFadeDuration = 0.12f;
 
         [SerializeField]
-        private bool logAnimationSetup = true;
+        private bool logAnimationSetup = false;
 
         private bool hasSpeed;
         private bool hasMoving;
@@ -85,6 +91,8 @@ namespace ApexShift.Runtime.Player
         private bool hasTorchUse;
         private bool hasChop;
         private bool hasMine;
+        private bool hasHurt;
+        private bool hasDeath;
         private bool hasStateFallback;
         private bool hasSwimmingStateFallback;
         private bool loggedMissingStateFallback;
@@ -105,15 +113,16 @@ namespace ApexShift.Runtime.Player
 
             CacheParameters();
 
-            if (logAnimationSetup)
+            if (logAnimationSetup || animator == null || animator.runtimeAnimatorController == null)
             {
                 Debug.Log(
                     $"[PlayerAnimationDriver] Animator={(animator != null ? animator.name : "missing")}, " +
+                    $"controller={(animator != null && animator.runtimeAnimatorController != null ? animator.runtimeAnimatorController.name : "missing")}, " +
                     $"hasSpeed={hasSpeed}, hasMoving={hasMoving}, hasSprinting={hasSprinting}, " +
                     $"hasAttack={hasAttack}, hasInteract={hasInteract}, hasSwimming={hasSwimming}, " +
                     $"hasGather={hasGather}, hasSpearAttack={hasSpearAttack}, hasBowAttack={hasBowAttack}, " +
                     $"hasAxeUse={hasAxeUse}, hasPickaxeUse={hasPickaxeUse}, hasTorchUse={hasTorchUse}, " +
-                    $"hasChop={hasChop}, hasMine={hasMine}, " +
+                    $"hasChop={hasChop}, hasMine={hasMine}, hasHurt={hasHurt}, hasDeath={hasDeath}, " +
                     $"hasStateFallback={hasStateFallback}, hasSwimmingStateFallback={hasSwimmingStateFallback}",
                     this);
             }
@@ -274,6 +283,16 @@ namespace ApexShift.Runtime.Player
             else TriggerGather();
         }
 
+        public void TriggerHurt()
+        {
+            TrySetTrigger(hurtTrigger, hasHurt);
+        }
+
+        public void TriggerDeath()
+        {
+            TrySetTrigger(deathTrigger, hasDeath);
+        }
+
         /// <summary>
         /// Called by PlayerWaterDetector to enable or disable the swimming animation state.
         /// Has no effect if the Animator controller does not contain an "IsSwimming" bool parameter.
@@ -341,10 +360,12 @@ namespace ApexShift.Runtime.Player
             hasTorchUse = false;
             hasChop = false;
             hasMine = false;
+            hasHurt = false;
+            hasDeath = false;
             hasStateFallback = false;
             hasSwimmingStateFallback = false;
 
-            if (animator == null)
+            if (animator == null || animator.runtimeAnimatorController == null)
             {
                 return;
             }
@@ -406,6 +427,14 @@ namespace ApexShift.Runtime.Player
                 else if (parameter.name == mineTrigger)
                 {
                     hasMine = parameter.type == AnimatorControllerParameterType.Trigger;
+                }
+                else if (parameter.name == hurtTrigger)
+                {
+                    hasHurt = parameter.type == AnimatorControllerParameterType.Trigger;
+                }
+                else if (parameter.name == deathTrigger)
+                {
+                    hasDeath = parameter.type == AnimatorControllerParameterType.Trigger;
                 }
             }
 

--- a/Assets/_Project/Scripts/Runtime/UI/GameSnapshotProvider.cs
+++ b/Assets/_Project/Scripts/Runtime/UI/GameSnapshotProvider.cs
@@ -101,10 +101,9 @@ namespace ApexShift.Runtime.UI.Snapshots
             int fireSources = FireSourceRegistry.SourceCount;
             int activeFireSources = FireSourceRegistry.ActiveSourceCount;
             int landmarkCount = LandmarkRegistry.LandmarkCount;
+            int discoveredLandmarks = LandmarkRegistry.DiscoveredCount;
             string[] recentEvents = GameEventBus.GetRecentEventLines(8);
-            var snapshot = new WorldDebugSnapshot(worldGenerator != null ? worldGenerator.Seed : 0, player != null ? player.position : Vector3.zero, player != null, resourceCount, creatureCount, foodCount, plantFood, meatFood, navOnMesh, Mathf.Max(0, navTotal - navOnMesh), hungryCreatures, storageContainers, pickupCount, fireSources, activeFireSources, smoothedFps, Time.realtimeSinceStartup, recentEvents);
-            snapshot.landmarkCount = landmarkCount;
-            return snapshot;
+            return new WorldDebugSnapshot(worldGenerator != null ? worldGenerator.Seed : 0, player != null ? player.position : Vector3.zero, player != null, resourceCount, creatureCount, foodCount, plantFood, meatFood, navOnMesh, Mathf.Max(0, navTotal - navOnMesh), hungryCreatures, storageContainers, pickupCount, fireSources, activeFireSources, landmarkCount, discoveredLandmarks, smoothedFps, Time.realtimeSinceStartup, recentEvents);
         }
         private void ResolveReferences()
         {

--- a/Assets/_Project/Scripts/Runtime/UI/WorldDebugSnapshot.cs
+++ b/Assets/_Project/Scripts/Runtime/UI/WorldDebugSnapshot.cs
@@ -24,6 +24,7 @@ namespace ApexShift.Runtime.UI.Snapshots
         public int fireSourceCount;
         public int activeFireSourceCount;
         public int landmarkCount;
+        public int discoveredLandmarkCount;
         public float fps;
         public float realtimeSinceStartup;
         public string[] recentEvents = Array.Empty<string>();
@@ -31,16 +32,21 @@ namespace ApexShift.Runtime.UI.Snapshots
         public static WorldDebugSnapshot Empty => new WorldDebugSnapshot();
         public WorldDebugSnapshot() { }
         public WorldDebugSnapshot(int seed, Vector3 playerPosition, bool hasPlayer, int resourceCount, int creatureCount, int foodSourceCount, int plantFoodSourceCount, int meatFoodSourceCount, int navAgentsOnMesh, int navAgentsOffMesh, int hungryCreatureCount, float fps, float realtimeSinceStartup)
-            : this(seed, playerPosition, hasPlayer, resourceCount, creatureCount, foodSourceCount, plantFoodSourceCount, meatFoodSourceCount, navAgentsOnMesh, navAgentsOffMesh, hungryCreatureCount, 0, 0, 0, 0, fps, realtimeSinceStartup, Array.Empty<string>())
+            : this(seed, playerPosition, hasPlayer, resourceCount, creatureCount, foodSourceCount, plantFoodSourceCount, meatFoodSourceCount, navAgentsOnMesh, navAgentsOffMesh, hungryCreatureCount, 0, 0, 0, 0, 0, 0, fps, realtimeSinceStartup, Array.Empty<string>())
         {
         }
 
         public WorldDebugSnapshot(int seed, Vector3 playerPosition, bool hasPlayer, int resourceCount, int creatureCount, int foodSourceCount, int plantFoodSourceCount, int meatFoodSourceCount, int navAgentsOnMesh, int navAgentsOffMesh, int hungryCreatureCount, float fps, float realtimeSinceStartup, IReadOnlyList<string> recentEvents)
-            : this(seed, playerPosition, hasPlayer, resourceCount, creatureCount, foodSourceCount, plantFoodSourceCount, meatFoodSourceCount, navAgentsOnMesh, navAgentsOffMesh, hungryCreatureCount, 0, 0, 0, 0, fps, realtimeSinceStartup, recentEvents)
+            : this(seed, playerPosition, hasPlayer, resourceCount, creatureCount, foodSourceCount, plantFoodSourceCount, meatFoodSourceCount, navAgentsOnMesh, navAgentsOffMesh, hungryCreatureCount, 0, 0, 0, 0, 0, 0, fps, realtimeSinceStartup, recentEvents)
         {
         }
 
         public WorldDebugSnapshot(int seed, Vector3 playerPosition, bool hasPlayer, int resourceCount, int creatureCount, int foodSourceCount, int plantFoodSourceCount, int meatFoodSourceCount, int navAgentsOnMesh, int navAgentsOffMesh, int hungryCreatureCount, int storageContainerCount, int pickupCount, int fireSourceCount, int activeFireSourceCount, float fps, float realtimeSinceStartup, IReadOnlyList<string> recentEvents)
+            : this(seed, playerPosition, hasPlayer, resourceCount, creatureCount, foodSourceCount, plantFoodSourceCount, meatFoodSourceCount, navAgentsOnMesh, navAgentsOffMesh, hungryCreatureCount, storageContainerCount, pickupCount, fireSourceCount, activeFireSourceCount, 0, 0, fps, realtimeSinceStartup, recentEvents)
+        {
+        }
+
+        public WorldDebugSnapshot(int seed, Vector3 playerPosition, bool hasPlayer, int resourceCount, int creatureCount, int foodSourceCount, int plantFoodSourceCount, int meatFoodSourceCount, int navAgentsOnMesh, int navAgentsOffMesh, int hungryCreatureCount, int storageContainerCount, int pickupCount, int fireSourceCount, int activeFireSourceCount, int landmarkCount, int discoveredLandmarkCount, float fps, float realtimeSinceStartup, IReadOnlyList<string> recentEvents)
         {
             this.seed = seed;
             this.playerPosition = playerPosition;
@@ -57,7 +63,8 @@ namespace ApexShift.Runtime.UI.Snapshots
             this.pickupCount = Math.Max(0, pickupCount);
             this.fireSourceCount = Math.Max(0, fireSourceCount);
             this.activeFireSourceCount = Math.Max(0, activeFireSourceCount);
-            this.landmarkCount = 0;
+            this.landmarkCount = Math.Max(0, landmarkCount);
+            this.discoveredLandmarkCount = Math.Max(0, discoveredLandmarkCount);
             this.fps = Mathf.Max(0f, fps);
             this.realtimeSinceStartup = Mathf.Max(0f, realtimeSinceStartup);
             this.recentEvents = recentEvents != null ? recentEvents.Where(line => !string.IsNullOrWhiteSpace(line)).ToArray() : Array.Empty<string>();

--- a/Assets/_Project/Scripts/Runtime/World/Landmarks/LandmarkWorldGenerator.cs
+++ b/Assets/_Project/Scripts/Runtime/World/Landmarks/LandmarkWorldGenerator.cs
@@ -9,6 +9,7 @@ namespace ApexShift.Runtime.World.Landmarks
         public static void Generate(Transform parent, IslandTopographyRuntime topography, int seed)
         {
             LandmarkRegistry.ClearForWorldRegeneration();
+            ClearExistingLandmarkChildren(parent);
             if (parent == null || topography == null || !topography.IsBuilt || topography.GetGridReadOnly() == null) return;
 
             CreateLandmarkObject(parent, "old_tree", LandmarkType.OldTree, "Great Old Tree", "A huge ancient tree used as a natural orientation point.", PickCell(topography, c => c.IsLand && c.TerrainType == TerrainType.Forest, new Vector2(-46f, 8f), seed + 11), true);
@@ -27,6 +28,33 @@ namespace ApexShift.Runtime.World.Landmarks
             runtime.Configure(id, type, displayName, description, discovered);
             BuildVisual(runtime.transform, type);
             return runtime;
+        }
+
+        private static void ClearExistingLandmarkChildren(Transform parent)
+        {
+            if (parent == null)
+            {
+                return;
+            }
+
+            for (int i = parent.childCount - 1; i >= 0; i--)
+            {
+                Transform child = parent.GetChild(i);
+                if (child == null)
+                {
+                    continue;
+                }
+
+                GameObject go = child.gameObject;
+                if (Application.isPlaying)
+                {
+                    UnityEngine.Object.Destroy(go);
+                }
+                else
+                {
+                    UnityEngine.Object.DestroyImmediate(go);
+                }
+            }
         }
 
         private static Vector3 PickCell(IslandTopographyRuntime topography, Predicate<TopographyCell> predicate, Vector2 target, int salt)

--- a/Assets/_Project/Scripts/Tests/Unit/UI/WorldDebugSnapshotLandmarkTests.cs
+++ b/Assets/_Project/Scripts/Tests/Unit/UI/WorldDebugSnapshotLandmarkTests.cs
@@ -1,0 +1,67 @@
+using ApexShift.Runtime.UI.Snapshots;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace ApexShift.Tests.Unit.UI
+{
+    public sealed class WorldDebugSnapshotLandmarkTests
+    {
+        [Test]
+        public void ConstructorStoresLandmarkCounts()
+        {
+            WorldDebugSnapshot snapshot = new WorldDebugSnapshot(
+                seed: 42,
+                playerPosition: Vector3.zero,
+                hasPlayer: true,
+                resourceCount: 1,
+                creatureCount: 2,
+                foodSourceCount: 3,
+                plantFoodSourceCount: 4,
+                meatFoodSourceCount: 5,
+                navAgentsOnMesh: 6,
+                navAgentsOffMesh: 7,
+                hungryCreatureCount: 8,
+                storageContainerCount: 9,
+                pickupCount: 10,
+                fireSourceCount: 11,
+                activeFireSourceCount: 12,
+                landmarkCount: 5,
+                discoveredLandmarkCount: 3,
+                fps: 60f,
+                realtimeSinceStartup: 1f,
+                recentEvents: null);
+
+            Assert.AreEqual(5, snapshot.landmarkCount);
+            Assert.AreEqual(3, snapshot.discoveredLandmarkCount);
+        }
+
+        [Test]
+        public void ConstructorClampsNegativeLandmarkCounts()
+        {
+            WorldDebugSnapshot snapshot = new WorldDebugSnapshot(
+                0,
+                Vector3.zero,
+                false,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                -10,
+                -5,
+                0f,
+                0f,
+                null);
+
+            Assert.AreEqual(0, snapshot.landmarkCount);
+            Assert.AreEqual(0, snapshot.discoveredLandmarkCount);
+        }
+    }
+}

--- a/Docs/world/landmarks-and-player-animation.md
+++ b/Docs/world/landmarks-and-player-animation.md
@@ -1,0 +1,131 @@
+# Landmark runtime and player animation polish
+
+This document covers Batch D:
+
+- #54 landmark runtime and map markers
+- #60 player character animation binding
+
+## Landmark runtime
+
+Runtime landmark support is based on:
+
+```text
+Assets/_Project/Scripts/Runtime/World/Landmarks/LandmarkRuntime.cs
+Assets/_Project/Scripts/Runtime/World/Landmarks/LandmarkRegistry.cs
+Assets/_Project/Scripts/Runtime/World/Landmarks/LandmarkType.cs
+Assets/_Project/Scripts/Runtime/World/Landmarks/LandmarkWorldGenerator.cs
+```
+
+Generated landmark types:
+
+- `old_tree`
+- `ruins`
+- `pond`
+- `camp`
+- `cave_placeholder`
+
+Each landmark stores:
+
+- stable id
+- type
+- display name
+- description
+- world position
+- `discovered` flag for future fog-of-war/discovery work
+
+## Map/minimap
+
+Landmark markers are read from `LandmarkRegistry.Landmarks`.
+
+Integrated views:
+
+```text
+Assets/_Project/Scripts/Presentation/HUD/MapScreenUI.cs
+Assets/_Project/Scripts/Presentation/HUD/MiniMapUI.cs
+```
+
+The full map and minimap use landmark colors/sizes based on `LandmarkType`.
+
+## Save/load
+
+Landmarks are serialized through:
+
+```text
+Assets/_Project/Scripts/Core/Save/LandmarkSaveData.cs
+Assets/_Project/Scripts/Core/Save/WorldSaveData.cs
+Assets/_Project/Scripts/Runtime/Save/GameSaveService.cs
+```
+
+`GameSaveService` captures `LandmarkRegistry.CaptureSaveData()` into `WorldSaveData.landmarkStates` and restores missing landmarks through `LandmarkRegistry.RestoreFromSaveData()`.
+
+## Snapshot/debug
+
+`WorldDebugSnapshot` now stores both:
+
+- `landmarkCount`
+- `discoveredLandmarkCount`
+
+`GameSnapshotProvider` fills these from `LandmarkRegistry`.
+
+## Player animation binding
+
+Player animation binding uses:
+
+```text
+Assets/_Project/Scripts/Runtime/Player/PlayerAnimationDriver.cs
+Assets/_Project/Scripts/Runtime/Player/KevinIglesiasPlayerAnimationBinder.cs
+```
+
+The runtime flow is:
+
+1. `WorldGeneratorRuntime` creates/configures the player.
+2. `PlayerAnimationDriver` receives movement/input state.
+3. `KevinIglesiasPlayerAnimationBinder` resolves or generates a controller in Editor when imported animation clips are available.
+4. Combat and item use call animation triggers through `PlayerAnimationDriver.TriggerItemUse()`.
+
+Supported semantic states/triggers:
+
+- idle
+- walk
+- run/sprint
+- swim
+- attack
+- spear attack
+- bow attack
+- axe/chop
+- pickaxe/mine
+- torch use
+- gather/interact
+- hurt/death when matching clips exist
+
+## Editor report
+
+Use:
+
+```text
+Apex Shift -> Animation -> Player Binding Report
+```
+
+This scans imported animation clips, reports which roles were resolved, and can regenerate the generated player controller.
+
+## Manual test
+
+### Landmark test
+
+1. Start New Game.
+2. Confirm at least one `Landmark_*` object exists under `LandmarkRoot`.
+3. Open map and confirm landmark markers are visible.
+4. Check minimap for nearby landmark markers.
+5. Save and load.
+6. Confirm landmarks are restored and markers still appear.
+7. Check debug/snapshot count for `landmarkCount`.
+
+### Animation test
+
+1. Open `Apex Shift -> Animation -> Player Binding Report`.
+2. Confirm Idle/Walk/Run clips are resolved or see which clips are missing.
+3. Generate/refresh the controller.
+4. Start New Game.
+5. Check idle, walk, run/sprint.
+6. Try spear/bow/axe/pickaxe/torch actions and confirm triggers are sent.
+7. Confirm missing clips do not break gameplay and do not spam NullReferenceException.


### PR DESCRIPTION
## Summary

Implements Batch D world/gameplay polish:

- #54 landmark runtime and map/debug marker polish
- #60 player animation binding polish

## Changes

### Landmarks

- Keeps landmark generation deterministic and cleans stale `LandmarkRoot` children before regeneration.
- Preserves existing runtime landmark pipeline:
  - `LandmarkRuntime`
  - `LandmarkRegistry`
  - `LandmarkWorldGenerator`
  - map/minimap marker integration
  - save/load via `LandmarkSaveData`
- Fixes `WorldDebugSnapshot` so `landmarkCount` is actually stored in the snapshot constructor instead of being reset to `0`.
- Adds `discoveredLandmarkCount` for future fog-of-war/discovery work.
- Updates `GameSnapshotProvider` to capture both total and discovered landmark counts.
- Adds unit tests for landmark snapshot counts.

### Player animation

- Adds an editor report window:

```text
Apex Shift -> Animation -> Player Binding Report
```

- The report scans imported animation clips using the existing Kevin Iglesias binding resolver.
- The window shows which clips resolve to Idle/Walk/Run/Swim/Attack/Spear/Bow/Axe/Pickaxe/Torch/Gather/Hurt/Death.
- Adds a button to regenerate the generated player animator controller.
- Extends `PlayerAnimationDriver` with explicit `Hurt` and `Death` trigger support.
- Reduces successful animation setup logging by default while still logging missing animator/controller state.

### Docs

- Adds `Docs/world/landmarks-and-player-animation.md` with manual test flows.

## Manual test

### Landmarks

1. Start New Game.
2. Confirm `LandmarkRoot` contains generated `Landmark_*` objects.
3. Open map and confirm landmark markers are visible.
4. Check minimap markers near landmarks.
5. Save and load.
6. Confirm landmarks still exist and map/minimap markers remain.
7. Confirm debug snapshot landmark count is non-zero.

### Animations

1. Open `Apex Shift -> Animation -> Player Binding Report`.
2. Refresh the report and confirm Idle/Walk/Run candidates are detected.
3. Generate/refresh the controller.
4. Start New Game.
5. Test idle, walk/run, sprint, swim if available, attack and tool triggers.
6. Confirm missing clips do not throw NullReferenceException or spam console errors.

Closes #54
Closes #60
