### PR TITLE
Implement tent sleep survival loop

### DIFF
--- a/Assets/_Project/Scripts/Runtime/Buildings/PlaceableStructureRuntime.cs
+++ b/Assets/_Project/Scripts/Runtime/Buildings/PlaceableStructureRuntime.cs
@@ -23,17 +23,22 @@ namespace ApexShift.Runtime.Buildings
         public string InstanceId => Normalize(instanceId, string.Empty);
         public Vector3 FootprintSize => new Vector3(Mathf.Max(0.25f, footprintSize.x), Mathf.Max(0.25f, footprintSize.y), Mathf.Max(0.25f, footprintSize.z));
         public bool BlocksPlacement => blocksPlacement;
-        public string Prompt => string.IsNullOrWhiteSpace(prompt) ? $"Use {BuildingId}" : prompt;
-        public int Priority => 25;
-        public float InteractionDuration => Mathf.Max(0.05f, interactionDuration);
+        public string Prompt => SleepRuntime != null ? SleepRuntime.Prompt : (string.IsNullOrWhiteSpace(prompt) ? $"Use {BuildingId}" : prompt);
+        public int Priority => BuildingId == "tent" ? 35 : 25;
+        public float InteractionDuration => SleepRuntime != null ? SleepRuntime.InteractionDuration : Mathf.Max(0.05f, interactionDuration);
         public StorageContainerRuntime StorageContainer => GetComponent<StorageContainerRuntime>();
         public TrapDamageRuntime TrapDamage => GetComponent<TrapDamageRuntime>();
         public CampfireRuntime Campfire => GetComponent<CampfireRuntime>();
+        public TentSleepRuntime SleepRuntime => GetComponent<TentSleepRuntime>();
 
         private void OnEnable()
         {
             if (!string.IsNullOrWhiteSpace(buildingId))
             {
+                EnsureStorageContainerIfNeeded();
+                EnsureTrapDamageIfNeeded();
+                EnsureCampfireIfNeeded();
+                EnsureTentSleepIfNeeded();
                 BuildingRegistry.Active?.Register(this);
             }
         }
@@ -57,6 +62,7 @@ namespace ApexShift.Runtime.Buildings
             EnsureStorageContainerIfNeeded();
             EnsureTrapDamageIfNeeded();
             EnsureCampfireIfNeeded();
+            EnsureTentSleepIfNeeded();
             BuildingRegistry.Active?.Register(this);
         }
 
@@ -81,6 +87,12 @@ namespace ApexShift.Runtime.Buildings
                 return false;
             }
 
+            TentSleepRuntime sleepRuntime = SleepRuntime;
+            if (sleepRuntime != null)
+            {
+                return sleepRuntime.CanInteract(actor);
+            }
+
             return true;
         }
 
@@ -103,6 +115,13 @@ namespace ApexShift.Runtime.Buildings
             {
                 Debug.Log($"[Building] Forwarding interaction to campfire '{InstanceId}'.", this);
                 return campfire.Interact(actor);
+            }
+
+            TentSleepRuntime sleepRuntime = SleepRuntime;
+            if (sleepRuntime != null)
+            {
+                Debug.Log($"[Building] Forwarding interaction to tent sleep '{InstanceId}'.", this);
+                return sleepRuntime.TrySleep(actor).Success;
             }
 
             Debug.Log($"[Building] Interacted with {BuildingId} ({InstanceId}).", this);
@@ -145,6 +164,14 @@ namespace ApexShift.Runtime.Buildings
             }
         }
 
+        private void EnsureTentSleepIfNeeded()
+        {
+            if (BuildingId == "tent")
+            {
+                _ = GetComponent<TentSleepRuntime>() ?? gameObject.AddComponent<TentSleepRuntime>();
+            }
+        }
+
         private void EnsureCollider()
         {
             Collider existing = GetComponentInChildren<Collider>();
@@ -166,7 +193,7 @@ namespace ApexShift.Runtime.Buildings
                 case "campfire": return "Use campfire";
                 case "wall": return "Inspect wall";
                 case "trap": return "Inspect trap";
-                case "tent": return "Rest at tent";
+                case "tent": return "Sleep in tent";
                 default: return "Use structure";
             }
         }

--- a/Assets/_Project/Scripts/Runtime/Buildings/TentSleepResult.cs
+++ b/Assets/_Project/Scripts/Runtime/Buildings/TentSleepResult.cs
@@ -1,0 +1,36 @@
+namespace ApexShift.Runtime.Buildings
+{
+    public readonly struct TentSleepResult
+    {
+        public TentSleepResult(
+            bool success,
+            string message,
+            float hoursAdvanced,
+            float restDelta,
+            float staminaDelta,
+            float hungerDelta,
+            float healthDelta)
+        {
+            Success = success;
+            Message = message ?? string.Empty;
+            HoursAdvanced = hoursAdvanced;
+            RestDelta = restDelta;
+            StaminaDelta = staminaDelta;
+            HungerDelta = hungerDelta;
+            HealthDelta = healthDelta;
+        }
+
+        public bool Success { get; }
+        public string Message { get; }
+        public float HoursAdvanced { get; }
+        public float RestDelta { get; }
+        public float StaminaDelta { get; }
+        public float HungerDelta { get; }
+        public float HealthDelta { get; }
+
+        public static TentSleepResult Failed(string message)
+        {
+            return new TentSleepResult(false, message, 0f, 0f, 0f, 0f, 0f);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Runtime/Buildings/TentSleepRuntime.cs
+++ b/Assets/_Project/Scripts/Runtime/Buildings/TentSleepRuntime.cs
@@ -1,0 +1,165 @@
+using ApexShift.Runtime.Creatures;
+using ApexShift.Runtime.DayNight;
+using ApexShift.Runtime.Ecosystem;
+using ApexShift.Runtime.Player;
+using UnityEngine;
+
+namespace ApexShift.Runtime.Buildings
+{
+    [DisallowMultipleComponent]
+    public sealed class TentSleepRuntime : MonoBehaviour
+    {
+        [Header("Interaction")]
+        [SerializeField] private float sleepInteractionDuration = 1.2f;
+        [SerializeField] private float maxUseDistance = 3.0f;
+        [SerializeField] private string sleepPrompt = "Sleep in tent";
+
+        [Header("Recovery")]
+        [SerializeField, Range(0f, 100f)] private float minimumRestAfterSleep = 80f;
+        [SerializeField, Range(0f, 100f)] private float minimumStaminaAfterSleep = 70f;
+        [SerializeField, Range(0f, 100f)] private float hungerCost = 14f;
+        [SerializeField, Range(0f, 100f)] private float minimumHungerToSleep = 18f;
+        [SerializeField, Range(0f, 25f)] private float healthBonus = 2f;
+
+        [Header("Time Skip")]
+        [SerializeField] private bool sleepUntilMorningAtNight = true;
+        [SerializeField, Range(0.5f, 8f)] private float daytimeNapHours = 3f;
+        [SerializeField, Range(0f, 24f)] private float wakeUpHour = 6.25f;
+
+        [Header("Safety")]
+        [SerializeField] private bool blockSleepNearVarnak = true;
+        [SerializeField] private float unsafeVarnakRadius = 34f;
+
+        public string Prompt => sleepPrompt;
+        public float InteractionDuration => Mathf.Max(0.1f, sleepInteractionDuration);
+
+        public bool CanInteract(GameObject actor)
+        {
+            if (actor == null || !isActiveAndEnabled)
+            {
+                return false;
+            }
+
+            if (!IsActorCloseEnough(actor))
+            {
+                return false;
+            }
+
+            PlayerSurvivalRuntime survival = actor.GetComponent<PlayerSurvivalRuntime>();
+            return survival == null || !survival.IsDead;
+        }
+
+        public TentSleepResult TrySleep(GameObject actor)
+        {
+            if (actor == null)
+            {
+                return Report(TentSleepResult.Failed("Cannot sleep: missing player."), actor);
+            }
+
+            if (!IsActorCloseEnough(actor))
+            {
+                return Report(TentSleepResult.Failed("You are too far from the tent."), actor);
+            }
+
+            PlayerSurvivalRuntime survival = actor.GetComponent<PlayerSurvivalRuntime>();
+            if (survival == null || survival.Stats == null)
+            {
+                return Report(TentSleepResult.Failed("Cannot sleep: survival state is missing."), actor);
+            }
+
+            if (survival.IsDead)
+            {
+                return Report(TentSleepResult.Failed("Cannot sleep after death."), actor);
+            }
+
+            if (survival.Stats.Hunger <= Mathf.Max(0f, minimumHungerToSleep))
+            {
+                return Report(TentSleepResult.Failed("You are too hungry to sleep."), actor);
+            }
+
+            if (IsThreatenedByVarnak(actor.transform.position))
+            {
+                return Report(TentSleepResult.Failed("Cannot sleep while threatened."), actor);
+            }
+
+            DayNightRuntime dayNight = DayNightRuntime.Active;
+            float hoursAdvanced = ResolveSleepHours(dayNight);
+            TentSleepResult result = survival.ApplySleepRecovery(minimumRestAfterSleep, minimumStaminaAfterSleep, hungerCost, healthBonus, hoursAdvanced);
+
+            if (dayNight != null && hoursAdvanced > 0f)
+            {
+                dayNight.AdvanceHours(hoursAdvanced);
+            }
+
+            string message = result.Success
+                ? $"Slept for {hoursAdvanced:0.0}h. Rest +{result.RestDelta:0}, stamina +{result.StaminaDelta:0}, hunger {result.HungerDelta:0}."
+                : result.Message;
+
+            return Report(new TentSleepResult(result.Success, message, hoursAdvanced, result.RestDelta, result.StaminaDelta, result.HungerDelta, result.HealthDelta), actor);
+        }
+
+        private float ResolveSleepHours(DayNightRuntime dayNight)
+        {
+            if (dayNight == null)
+            {
+                return Mathf.Max(0.5f, daytimeNapHours);
+            }
+
+            float currentHour = dayNight.Hour;
+            if (sleepUntilMorningAtNight && dayNight.IsNight)
+            {
+                float targetHour = Mathf.Clamp(wakeUpHour, 0f, 24f);
+                float delta = targetHour - currentHour;
+                if (delta <= 0f)
+                {
+                    delta += 24f;
+                }
+
+                return Mathf.Clamp(delta, 1f, 12f);
+            }
+
+            return Mathf.Max(0.5f, daytimeNapHours);
+        }
+
+        private bool IsThreatenedByVarnak(Vector3 position)
+        {
+            if (!blockSleepNearVarnak)
+            {
+                return false;
+            }
+
+            EcosystemRuntime ecosystem = EcosystemRuntime.Instance;
+            if (ecosystem == null)
+            {
+                return false;
+            }
+
+            CreatureAgentView varnak = ecosystem.TryFindNearestCreatureById(position, "varnak", Mathf.Max(0f, unsafeVarnakRadius));
+            return varnak != null;
+        }
+
+        private bool IsActorCloseEnough(GameObject actor)
+        {
+            if (actor == null)
+            {
+                return false;
+            }
+
+            float maxDistance = Mathf.Max(0.25f, maxUseDistance);
+            return (actor.transform.position - transform.position).sqrMagnitude <= maxDistance * maxDistance;
+        }
+
+        private TentSleepResult Report(TentSleepResult result, GameObject actor)
+        {
+            Debug.Log($"[TentSleep] {result.Message}", this);
+
+            PlayerActionFeedback feedback = actor != null ? actor.GetComponent<PlayerActionFeedback>() : null;
+            if (feedback != null)
+            {
+                feedback.ShowMessage(result.Message, result.Success ? new Color(0.35f, 0.85f, 1f) : new Color(1f, 0.55f, 0.35f));
+            }
+
+            return result;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Runtime/Player/PlayerActionFeedback.cs
+++ b/Assets/_Project/Scripts/Runtime/Player/PlayerActionFeedback.cs
@@ -114,6 +114,11 @@ namespace ApexShift.Runtime.Player
             }
         }
 
+        public void ShowMessage(string message, Color flashColor)
+        {
+            TriggerFeedback(string.IsNullOrWhiteSpace(message) ? "Action" : message, flashColor);
+        }
+
         private void OnInteract()
         {
             TriggerFeedback("Interact", new Color(0.2f, 0.8f, 1f));

--- a/Assets/_Project/Scripts/Runtime/Player/PlayerSurvivalRuntime.cs
+++ b/Assets/_Project/Scripts/Runtime/Player/PlayerSurvivalRuntime.cs
@@ -1,6 +1,7 @@
 using System;
 using ApexShift.Core.Survival;
 using ApexShift.Core.Save;
+using ApexShift.Runtime.Buildings;
 using ApexShift.Runtime.Events;
 using ApexShift.Runtime.PlayerInput;
 using UnityEngine;
@@ -204,6 +205,51 @@ namespace ApexShift.Runtime.Player
             }
 
             return stats.ChangeStamina(amount);
+        }
+
+        public TentSleepResult ApplySleepRecovery(float minimumRest, float minimumStamina, float hungerCost, float healthBonus, float hoursAdvanced)
+        {
+            EnsureInitialized();
+            if (IsDead)
+            {
+                return TentSleepResult.Failed("Cannot sleep after death.");
+            }
+
+            float beforeRest = stats.Rest;
+            float beforeStamina = stats.Stamina;
+            float beforeHunger = stats.Hunger;
+            float beforeHealth = stats.Health;
+
+            float targetRest = Mathf.Clamp(minimumRest, 0f, rules.MaxRest);
+            if (stats.Rest < targetRest)
+            {
+                stats.ChangeRest(targetRest - stats.Rest);
+            }
+
+            float targetStamina = Mathf.Clamp(minimumStamina, 0f, rules.MaxStamina);
+            if (stats.Stamina < targetStamina)
+            {
+                stats.ChangeStamina(targetStamina - stats.Stamina);
+            }
+
+            if (healthBonus > 0f)
+            {
+                stats.ChangeHealth(healthBonus);
+            }
+
+            if (hungerCost > 0f && !stats.GodMode)
+            {
+                stats.ChangeHunger(-hungerCost);
+            }
+
+            return new TentSleepResult(
+                true,
+                "Slept in tent.",
+                Mathf.Max(0f, hoursAdvanced),
+                stats.Rest - beforeRest,
+                stats.Stamina - beforeStamina,
+                stats.Hunger - beforeHunger,
+                stats.Health - beforeHealth);
         }
 
         public void Restore(float health, float hunger, float stamina, float rest)

--- a/Assets/_Project/Scripts/Runtime/Time/DayNightRuntime.cs
+++ b/Assets/_Project/Scripts/Runtime/Time/DayNightRuntime.cs
@@ -98,6 +98,25 @@ namespace ApexShift.Runtime.DayNight
             DispatchEvents(result);
         }
 
+        public DayNightTickResult AdvanceHours(float hours)
+        {
+            EnsureState();
+            float safeHours = Mathf.Max(0f, hours);
+            if (safeHours <= 0f)
+            {
+                return new DayNightTickResult(0, false, false, state.TimeOfDay01, state.TimeOfDay01);
+            }
+
+            DayNightTickResult result = state.Advance(safeHours / 24f);
+            if (result.HasAnyEvent)
+            {
+                DispatchEvents(result);
+            }
+
+            Debug.Log($"[DayNight] Advanced time by {safeHours:0.00}h. Day={Day}, hour={Hour:0.00}", this);
+            return result;
+        }
+
         public void LoadFromWorldSaveData(int day, float timeOfDay01)
         {
             SetTime(day, timeOfDay01);

--- a/Assets/_Project/Scripts/Tests/Unit/Survival/PlayerSurvivalSleepTests.cs
+++ b/Assets/_Project/Scripts/Tests/Unit/Survival/PlayerSurvivalSleepTests.cs
@@ -1,0 +1,57 @@
+using ApexShift.Runtime.Buildings;
+using ApexShift.Runtime.Player;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace ApexShift.Tests.Unit.Survival
+{
+    public sealed class PlayerSurvivalSleepTests
+    {
+        [Test]
+        public void ApplySleepRecovery_RestoresRestAndStaminaAndConsumesHunger()
+        {
+            GameObject go = new GameObject("PlayerSurvivalSleepTest");
+            try
+            {
+                PlayerSurvivalRuntime survival = go.AddComponent<PlayerSurvivalRuntime>();
+                survival.Restore(80f, 60f, 10f, 15f);
+
+                TentSleepResult result = survival.ApplySleepRecovery(80f, 70f, 12f, 2f, 6f);
+
+                Assert.IsTrue(result.Success);
+                Assert.GreaterOrEqual(survival.Stats.Rest, 80f);
+                Assert.GreaterOrEqual(survival.Stats.Stamina, 70f);
+                Assert.AreEqual(48f, survival.Stats.Hunger, 0.01f);
+                Assert.AreEqual(6f, result.HoursAdvanced, 0.01f);
+                Assert.Greater(result.RestDelta, 0f);
+                Assert.Greater(result.StaminaDelta, 0f);
+                Assert.Less(result.HungerDelta, 0f);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void ApplySleepRecovery_FailsWhenDead()
+        {
+            GameObject go = new GameObject("PlayerSurvivalSleepTest");
+            try
+            {
+                PlayerSurvivalRuntime survival = go.AddComponent<PlayerSurvivalRuntime>();
+                survival.Restore(0f, 60f, 10f, 15f);
+
+                TentSleepResult result = survival.ApplySleepRecovery(80f, 70f, 12f, 2f, 6f);
+
+                Assert.IsFalse(result.Success);
+                Assert.AreEqual(0f, survival.Stats.Health, 0.01f);
+                Assert.AreEqual(60f, survival.Stats.Hunger, 0.01f);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Tests/Unit/Time/DayNightRuntimeTests.cs
+++ b/Assets/_Project/Scripts/Tests/Unit/Time/DayNightRuntimeTests.cs
@@ -75,5 +75,55 @@ namespace ApexShift.Tests.Unit.Time
                 Object.DestroyImmediate(go);
             }
         }
+
+        [Test]
+        public void AdvanceHours_AdvancesClockWithoutUsingRealSeconds()
+        {
+            GameObject go = new GameObject("DayNightRuntimeTest");
+            try
+            {
+                DayNightRuntime runtime = go.AddComponent<DayNightRuntime>();
+                runtime.SetAutoTick(false);
+                runtime.SetTickEcosystemOnDayChange(false);
+                runtime.LoadFromWorldSaveData(2, 0.25f);
+
+                runtime.AdvanceHours(3f);
+
+                Assert.AreEqual(2, runtime.Day);
+                Assert.AreEqual(9f, runtime.Hour, 0.01f);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void AdvanceHours_WrapsDayAndPublishesDayChanged()
+        {
+            GameObject go = new GameObject("DayNightRuntimeTest");
+            List<GameplayEvent> received = new List<GameplayEvent>();
+            try
+            {
+                DayNightRuntime runtime = go.AddComponent<DayNightRuntime>();
+                runtime.SetAutoTick(false);
+                runtime.SetTickEcosystemOnDayChange(false);
+                runtime.LoadFromWorldSaveData(7, 23f / 24f);
+
+                using (GameEventBus.Subscribe(received.Add))
+                {
+                    runtime.AdvanceHours(8f);
+                }
+
+                Assert.AreEqual(8, runtime.Day);
+                Assert.AreEqual(7f, runtime.Hour, 0.01f);
+                Assert.IsTrue(received.Exists(evt => evt.kind == GameplayEventKind.DayChanged));
+                Assert.IsTrue(received.Exists(evt => evt.kind == GameplayEventKind.MorningStarted));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
     }
 }

--- a/Docs/survival/tent-sleep.md
+++ b/Docs/survival/tent-sleep.md
@@ -1,0 +1,79 @@
+# Tent sleep survival loop
+
+Implements issue #71: sleeping in a placed tent.
+
+## Runtime flow
+
+A placed `tent` is still represented by `PlaceableStructureRuntime` and saved through the existing building save/load pipeline.
+
+When a structure is configured with `buildingId == "tent"`, it now receives:
+
+```text
+TentSleepRuntime
+```
+
+The interaction flow is:
+
+1. `PlayerInteractionController` finds `PlaceableStructureRuntime`.
+2. `PlaceableStructureRuntime` forwards tent interactions to `TentSleepRuntime`.
+3. `TentSleepRuntime` validates sleep conditions.
+4. `PlayerSurvivalRuntime.ApplySleepRecovery()` restores rest/stamina and applies hunger cost.
+5. `DayNightRuntime.AdvanceHours()` advances the clock and dispatches day/night/morning events.
+
+## Prototype rules
+
+Default sleep rules:
+
+- prompt: `Sleep in tent`
+- interaction duration: `1.2s`
+- max use distance: `3m`
+- minimum rest after sleep: `80`
+- minimum stamina after sleep: `70`
+- hunger cost: `14`
+- minimum hunger to sleep: `18`
+- small health bonus: `2`
+- if it is night: sleep until around `06:15`
+- if it is day: nap for `3h`
+- block sleep if a living Varnak is within `34m`
+
+## Failure cases
+
+Sleep is blocked when:
+
+- the actor is missing,
+- the player is too far from the tent,
+- `PlayerSurvivalRuntime` is missing,
+- the player is dead,
+- hunger is too low,
+- a Varnak is nearby.
+
+Failures are logged and routed through `PlayerActionFeedback.ShowMessage()` when available.
+
+## Save/load
+
+No extra save data is required for the first prototype.
+
+The tent itself is already saved as a building. On restore, `PlaceableStructureRuntime.Configure()` runs again and re-attaches `TentSleepRuntime` for `buildingId == "tent"`.
+
+## Manual test
+
+1. Start New Game.
+2. Craft/place a `tent`.
+3. Approach the tent.
+4. Confirm prompt says `Sleep in tent`.
+5. Lower rest/stamina/hunger through debug or gameplay.
+6. Interact with the tent.
+7. Confirm rest and stamina increase.
+8. Confirm hunger decreases.
+9. Confirm time advances through `DayNightRuntime`.
+10. Try sleeping while a Varnak is nearby and confirm it is blocked.
+11. Save/load and verify the restored tent still allows sleeping.
+
+## Future improvements
+
+- authored sleep UI instead of log/flash feedback,
+- sleep interruption events,
+- comfort values per shelter type,
+- weather/night risk modifiers,
+- sleep cooldown or fatigue debt,
+- special behavior for sleeping near campfire.


### PR DESCRIPTION
## Summary

Clean conflict-free replacement for the closed PR #72. Implements #71: sleeping in a placed tent, rebased on current `main` after Batch B/C/D were merged.

## Changes

### Tent sleep interaction

- Adds `TentSleepRuntime`.
- Adds `TentSleepResult`.
- `PlaceableStructureRuntime` now attaches `TentSleepRuntime` when `buildingId == "tent"`.
- Tent interaction is forwarded from `PlaceableStructureRuntime` into the sleep runtime.
- Serialized tent prefabs and restored tents also get the sleep runtime attached.

### Survival recovery

- Adds `PlayerSurvivalRuntime.ApplySleepRecovery()` without overwriting the already-merged Batch C death/fatigue logic.
- Sleep restores rest up to a minimum target.
- Sleep restores stamina up to a minimum target.
- Sleep applies hunger cost.
- Sleep can apply a small health bonus.
- Sleep is blocked when the player is dead.

### Time skip

- Adds `DayNightRuntime.AdvanceHours()`.
- Sleeping at night skips toward morning.
- Sleeping during the day performs a shorter nap.
- Day/night/morning events still dispatch through the existing event flow.

### Safety / failure cases

Sleep is blocked when:

- player is too far from the tent,
- survival runtime is missing,
- player is dead,
- hunger is too low,
- a living Varnak is nearby.

### Feedback

- Adds `PlayerActionFeedback.ShowMessage()` so tent sleep can surface success/failure feedback without introducing a new UI stack.
- Also logs clear `[TentSleep]` messages.

### Tests / docs

- Adds sleep recovery unit tests.
- Adds day-night time skip unit tests.
- Adds `Docs/survival/tent-sleep.md`.

## Conflict resolution note

The previous PR #72 was based on an older `main` and conflicted with the merged Batch C survival changes. This branch starts from current `main` (`ed811b4`) and reapplies only the tent-sleep changes on top of the merged survival/death/fatigue runtime.

## Manual test

1. Start New Game.
2. Craft/place a `tent`.
3. Approach the tent and confirm prompt says `Sleep in tent`.
4. Lower rest/stamina and interact with the tent.
5. Confirm rest/stamina increase and hunger decreases.
6. Confirm `DayNightRuntime` advances time.
7. Try sleeping while a Varnak is nearby and confirm it is blocked.
8. Save/load and confirm the restored tent still supports sleep.

Closes #71
